### PR TITLE
Selected path selection

### DIFF
--- a/packages/fieldSettings/EditableFieldKeyDisplay.tsx
+++ b/packages/fieldSettings/EditableFieldKeyDisplay.tsx
@@ -1,0 +1,62 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import { materialCells, materialRenderers } from '@jsonforms/material-renderers'
+import { JsonForms } from '@jsonforms/react'
+import { useToolSettings } from './useFieldSettings'
+import { Box, Button, Grid, IconButton, TextField, ToggleButton, Toolbar, Typography } from '@mui/material'
+import * as Icons from '@mui/icons-material'
+import { renameField, useAppDispatch } from '@formswizard/state'
+import { pathToPathSegments, splitLastPath, filterNullOrUndef } from '@formswizard/utils'
+import { ToolSetting } from './ToolSettingType'
+import { useWizardSelection } from './useWizardSelection'
+
+function EditableFieldKeyDisplay() {
+  const dispatch = useAppDispatch()
+  const { selectedKeyName, selectedPath, selectionDisplayName } = useWizardSelection()
+
+  const [showKeyEditor, setShowKeyEditor] = useState(false)
+  const [newKey, setNewKey] = useState<string>('')
+
+  const keyIsEditable = Boolean(selectedKeyName)
+  useEffect(() => {
+    if (typeof selectedKeyName !== 'string') return
+    setNewKey(selectedKeyName)
+  }, [selectedKeyName])
+
+  const toggleKeyEditor = useCallback(() => {
+    setShowKeyEditor(!showKeyEditor)
+  }, [showKeyEditor])
+
+  const handleKeyChange = useCallback(() => {
+    if (typeof selectedPath !== 'string') return
+    dispatch(renameField({ path: selectedPath, newFieldName: newKey }))
+    setShowKeyEditor(false)
+  }, [newKey, selectedPath])
+  return (
+    <>
+      <Typography variant="h6" component="div">
+        Settings for
+        {!showKeyEditor && (
+          <>
+            <span> {selectionDisplayName}</span>
+            {keyIsEditable && (
+              <IconButton onClick={toggleKeyEditor}>{showKeyEditor ? <Icons.EditOff /> : <Icons.Edit />}</IconButton>
+            )}
+          </>
+        )}
+        {showKeyEditor && (
+          <Grid item>
+            <TextField
+              placeholder={'Key name'}
+              value={newKey}
+              onChange={(e) => setNewKey(e.target.value)}
+              label="Key"
+            />
+            <Button onClick={handleKeyChange}>ok</Button>
+          </Grid>
+        )}
+      </Typography>
+    </>
+  )
+}
+
+export default EditableFieldKeyDisplay

--- a/packages/fieldSettings/FieldSettingsView.tsx
+++ b/packages/fieldSettings/FieldSettingsView.tsx
@@ -6,8 +6,8 @@ import { Box, Button, Grid, IconButton, TextField, ToggleButton, Toolbar, Typogr
 import * as Icons from '@mui/icons-material'
 import {
   renameField,
-  selectElement,
   selectSelectedElementJsonSchema,
+  selectSelectedPath,
   useAppDispatch,
   useAppSelector,
 } from '@formswizard/state'
@@ -20,48 +20,50 @@ type FieldSettingsViewProps = {
 
 export function FieldSettingsView({ additionalToolSettings }: FieldSettingsViewProps) {
   const dispatch = useAppDispatch()
-  const { handleChange, toolSettingsJsonSchema, tooldataBuffer, selectedKey, selectedElementJsonSchema } =
-    useToolSettings({ additionalToolSettings })
-  const [showKeyEditor, setShowKeyEditor] = useState(false)
-  const [newKey, setNewKey] = useState<string>('')
+  const { handleChange, toolSettingsJsonSchema, tooldataBuffer, selectedElementJsonSchema } = useToolSettings({
+    additionalToolSettings,
+  })
+  const selectedPath = useAppSelector(selectSelectedPath)
+  // const [showKeyEditor, setShowKeyEditor] = useState(false)
+  // const [newKey, setNewKey] = useState<string>('')
 
-  const key = useMemo(() => {
-    const [lastPathSegment] = splitLastPath(selectedKey || '')
-    return lastPathSegment
-  }, [selectedKey])
+  // const key = useMemo(() => {
+  //   const [lastPathSegment] = splitLastPath(selectedKey || '')
+  //   return lastPathSegment
+  // }, [selectedKey])
 
-  const keyIsEditable = Boolean(selectedElementJsonSchema && selectedElementJsonSchema.type !== 'object')
-  useEffect(() => {
-    if (key === undefined) return
-    setNewKey(key)
-  }, [key])
+  // const keyIsEditable = Boolean(selectedElementJsonSchema && selectedElementJsonSchema.type !== 'object')
+  // useEffect(() => {
+  //   if (key === undefined) return
+  //   setNewKey(key)
+  // }, [key])
 
-  const toggleKeyEditor = useCallback(() => {
-    setShowKeyEditor(!showKeyEditor)
-  }, [showKeyEditor])
+  // const toggleKeyEditor = useCallback(() => {
+  //   setShowKeyEditor(!showKeyEditor)
+  // }, [showKeyEditor])
 
-  const handleKeyChange = useCallback(() => {
-    if (!selectedKey || selectedKey.length <= 0) return
-    const [lastPathSegment, path] = splitLastPath(selectedKey)
-    if (lastPathSegment === undefined) return
-    dispatch(selectElement(undefined))
-    dispatch(renameField({ path: selectedKey, newFieldName: newKey }))
-    const newPath = filterNullOrUndef([path, newKey]).join('.')
-    dispatch(selectElement(newPath))
-  }, [newKey, selectedKey])
+  // const handleKeyChange = useCallback(() => {
+  //   if (!selectedKey || selectedKey.length <= 0) return
+  //   const [lastPathSegment, path] = splitLastPath(selectedKey)
+  //   if (lastPathSegment === undefined) return
+  //   dispatch(selectElement(undefined))
+  //   dispatch(renameField({ path: selectedKey, newFieldName: newKey }))
+  //   const newPath = filterNullOrUndef([path, newKey]).join('.')
+  //   dispatch(selectElement(newPath))
+  // }, [newKey, selectedKey])
 
   return (
     <>
       <Toolbar>
         <Typography variant="h6" noWrap component="div">
-          Settings for {key || ''}
-          {keyIsEditable && (
+          Settings for {selectedPath || ''}
+          {/* {keyIsEditable && (
             <IconButton onClick={toggleKeyEditor}>{showKeyEditor ? <Icons.EditOff /> : <Icons.Edit />}</IconButton>
-          )}
+          )} */}
         </Typography>
       </Toolbar>
-      <Grid container direction={'column'} spacing={2} sx={{ m: 2 }}>
-        {showKeyEditor && (
+      <Grid container direction={'column'} spacing={2} sx={{ p: 2 }}>
+        {/* {showKeyEditor && (
           <Grid item>
             <TextField
               placeholder={'Key name'}
@@ -71,7 +73,7 @@ export function FieldSettingsView({ additionalToolSettings }: FieldSettingsViewP
             />
             <Button onClick={handleKeyChange}>ok</Button>
           </Grid>
-        )}
+        )} */}
         <Grid item>
           <Box>
             {!!toolSettingsJsonSchema && !!tooldataBuffer && (

--- a/packages/fieldSettings/FieldSettingsView.tsx
+++ b/packages/fieldSettings/FieldSettingsView.tsx
@@ -4,63 +4,25 @@ import { JsonForms } from '@jsonforms/react'
 import { useToolSettings } from './useFieldSettings'
 import { Box, Button, Grid, IconButton, TextField, ToggleButton, Toolbar, Typography } from '@mui/material'
 import * as Icons from '@mui/icons-material'
-import {
-  renameField,
-  selectSelectedElementJsonSchema,
-  selectSelectedPath,
-  useAppDispatch,
-  useAppSelector,
-} from '@formswizard/state'
+import { renameField, useAppDispatch } from '@formswizard/state'
 import { pathToPathSegments, splitLastPath, filterNullOrUndef } from '@formswizard/utils'
 import { ToolSetting } from './ToolSettingType'
+import { useWizardSelection } from './useWizardSelection'
+import EditableFieldKeyDisplay from './EditableFieldKeyDisplay'
 
 type FieldSettingsViewProps = {
   additionalToolSettings?: ToolSetting[]
 }
 
 export function FieldSettingsView({ additionalToolSettings }: FieldSettingsViewProps) {
-  const dispatch = useAppDispatch()
-  const { handleChange, toolSettingsJsonSchema, tooldataBuffer, selectionDisplayName } = useToolSettings({
+  const { handleChange, toolSettingsJsonSchema, tooldataBuffer } = useToolSettings({
     additionalToolSettings,
   })
-  const selectedPath = useAppSelector(selectSelectedPath)
-  // const [showKeyEditor, setShowKeyEditor] = useState(false)
-  // const [newKey, setNewKey] = useState<string>('')
-
-  // const key = useMemo(() => {
-  //   const [lastPathSegment] = splitLastPath(selectedKey || '')
-  //   return lastPathSegment
-  // }, [selectedKey])
-
-  // const keyIsEditable = Boolean(selectedElementJsonSchema && selectedElementJsonSchema.type !== 'object')
-  // useEffect(() => {
-  //   if (key === undefined) return
-  //   setNewKey(key)
-  // }, [key])
-
-  // const toggleKeyEditor = useCallback(() => {
-  //   setShowKeyEditor(!showKeyEditor)
-  // }, [showKeyEditor])
-
-  // const handleKeyChange = useCallback(() => {
-  //   if (!selectedKey || selectedKey.length <= 0) return
-  //   const [lastPathSegment, path] = splitLastPath(selectedKey)
-  //   if (lastPathSegment === undefined) return
-  //   dispatch(selectElement(undefined))
-  //   dispatch(renameField({ path: selectedKey, newFieldName: newKey }))
-  //   const newPath = filterNullOrUndef([path, newKey]).join('.')
-  //   dispatch(selectElement(newPath))
-  // }, [newKey, selectedKey])
 
   return (
     <>
       <Toolbar>
-        <Typography variant="h6" noWrap component="div">
-          Settings for {selectionDisplayName || ''}
-          {/* {keyIsEditable && (
-            <IconButton onClick={toggleKeyEditor}>{showKeyEditor ? <Icons.EditOff /> : <Icons.Edit />}</IconButton>
-          )} */}
-        </Typography>
+        <EditableFieldKeyDisplay></EditableFieldKeyDisplay>
       </Toolbar>
       <Grid container direction={'column'} spacing={2} sx={{ p: 2 }}>
         {/* {showKeyEditor && (
@@ -72,8 +34,8 @@ export function FieldSettingsView({ additionalToolSettings }: FieldSettingsViewP
               label="Key"
             />
             <Button onClick={handleKeyChange}>ok</Button>
-          </Grid>
-        )} */}
+          </Grid>*/}
+        {/* )} */}
         <Grid item>
           <Box>
             {!!toolSettingsJsonSchema && !!tooldataBuffer && (

--- a/packages/fieldSettings/FieldSettingsView.tsx
+++ b/packages/fieldSettings/FieldSettingsView.tsx
@@ -20,7 +20,7 @@ type FieldSettingsViewProps = {
 
 export function FieldSettingsView({ additionalToolSettings }: FieldSettingsViewProps) {
   const dispatch = useAppDispatch()
-  const { handleChange, toolSettingsJsonSchema, tooldataBuffer, selectedElementJsonSchema } = useToolSettings({
+  const { handleChange, toolSettingsJsonSchema, tooldataBuffer, selectionDisplayName } = useToolSettings({
     additionalToolSettings,
   })
   const selectedPath = useAppSelector(selectSelectedPath)
@@ -56,7 +56,7 @@ export function FieldSettingsView({ additionalToolSettings }: FieldSettingsViewP
     <>
       <Toolbar>
         <Typography variant="h6" noWrap component="div">
-          Settings for {selectedPath || ''}
+          Settings for {selectionDisplayName || ''}
           {/* {keyIsEditable && (
             <IconButton onClick={toggleKeyEditor}>{showKeyEditor ? <Icons.EditOff /> : <Icons.Edit />}</IconButton>
           )} */}

--- a/packages/fieldSettings/useFieldSettings.tsx
+++ b/packages/fieldSettings/useFieldSettings.tsx
@@ -9,6 +9,7 @@ import {
   useAppDispatch,
   useAppSelector,
   selectJsonSchema,
+  selectSelectionDisplayName,
 } from '@formswizard/state'
 import { ToolSettingsDefinitions } from './ToolSettingsDefinition'
 import { JsonSchema, UISchemaElement } from '@jsonforms/core'
@@ -23,6 +24,7 @@ export type ToolSettingsDefinition = {
   tooldataBuffer: any
   uiSchema: UISchemaElement
   selectedPath?: string | null | undefined
+  selectionDisplayName: string | null | undefined
 }
 
 type ToolSettingsDefinitionProps = {
@@ -39,6 +41,7 @@ export function useToolSettings({
   const jsonSchema = useAppSelector(selectJsonSchema)
   const UIElementFromSelection = useAppSelector(selectUIElementFromSelection)
   const selectedElementJsonSchema = useAppSelector(selectSelectedElementJsonSchema)
+  const selectionDisplayName = useAppSelector(selectSelectionDisplayName)
   const prevSelectedPath = useRef(null)
   const context = useMemo(
     () => ({
@@ -57,7 +60,7 @@ export function useToolSettings({
       ? tool
       : null
   }, [selectedElementJsonSchema, UIElementFromSelection, context])
-
+  console.log(selectionDisplayName)
   const toolSettingsJsonSchema = useMemo(
     () =>
       toolSettings
@@ -132,7 +135,7 @@ export function useToolSettings({
     toolSettingsJsonSchema,
     tooldataBuffer,
     setToolDataBuffer,
-
+    selectionDisplayName,
     selectedPath,
     selectedElementJsonSchema,
   }

--- a/packages/fieldSettings/useFieldSettings.tsx
+++ b/packages/fieldSettings/useFieldSettings.tsx
@@ -3,7 +3,6 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { maxBy } from 'lodash'
 import {
   selectSelectedElementJsonSchema,
-  selectSelectedElementKey,
   selectSelectedPath,
   selectUIElementFromSelection,
   updateJsonSchemaByPath,
@@ -17,7 +16,7 @@ import { ToolSetting } from './ToolSettingType'
 
 export type ToolSettingsDefinition = {
   setToolDataBuffer: (value: ((prevState: any) => any) | any) => void
-  selectedKey?: string | null
+
   toolSettingsJsonSchema: JsonSchema | null
   selectedElementJsonSchema: JsonSchema | null
   handleChange: (event) => void
@@ -35,12 +34,12 @@ export function useToolSettings({
 }: ToolSettingsDefinitionProps = {}): ToolSettingsDefinition {
   const dispatch = useAppDispatch()
   const [tooldataBuffer, setToolDataBuffer] = useState({})
-  const selectedKey = useAppSelector(selectSelectedElementKey)
+
   const selectedPath = useAppSelector(selectSelectedPath)
   const jsonSchema = useAppSelector(selectJsonSchema)
   const UIElementFromSelection = useAppSelector(selectUIElementFromSelection)
   const selectedElementJsonSchema = useAppSelector(selectSelectedElementJsonSchema)
-  const prevSelectedKey = useRef(null)
+  const prevSelectedPath = useRef(null)
   const context = useMemo(
     () => ({
       rootSchema: jsonSchema,
@@ -121,10 +120,10 @@ export function useToolSettings({
   )
 
   useEffect(() => {
-    if (prevSelectedKey.current === selectedPath) return
+    if (prevSelectedPath.current === selectedPath) return
     setToolDataBuffer(getToolData())
     //@ts-ignore
-    prevSelectedKey.current = selectedPath
+    prevSelectedPath.current = selectedPath
   }, [getToolData, selectedPath, tooldataBuffer])
 
   return {
@@ -133,7 +132,7 @@ export function useToolSettings({
     toolSettingsJsonSchema,
     tooldataBuffer,
     setToolDataBuffer,
-    selectedKey,
+
     selectedPath,
     selectedElementJsonSchema,
   }

--- a/packages/fieldSettings/useWizardSelection.tsx
+++ b/packages/fieldSettings/useWizardSelection.tsx
@@ -1,0 +1,35 @@
+import {
+  selectSelectedElementJsonSchema,
+  selectSelectedPath,
+  selectUIElementFromSelection,
+  useAppSelector,
+  selectSelectionDisplayName,
+  selectSelectedKeyName,
+} from '@formswizard/state'
+import { ToolSettingsDefinitions } from './ToolSettingsDefinition'
+import { JsonSchema, UISchemaElement } from '@jsonforms/core'
+import { ToolSetting } from './ToolSettingType'
+
+export type WizardSelection = {
+  selectedPath: string | null | undefined
+  selectedKeyName: string | null | undefined
+  UIElementFromSelection: UISchemaElement | null | undefined
+  selectedElementJsonSchema: JsonSchema | null | undefined
+  selectionDisplayName: string | null | undefined
+}
+
+export function useWizardSelection(): WizardSelection {
+  const selectedPath = useAppSelector(selectSelectedPath)
+  const selectedKeyName = useAppSelector(selectSelectedKeyName)
+  const UIElementFromSelection = useAppSelector(selectUIElementFromSelection)
+  const selectedElementJsonSchema = useAppSelector(selectSelectedElementJsonSchema)
+  const selectionDisplayName = useAppSelector(selectSelectionDisplayName)
+
+  return {
+    selectedPath,
+    selectedKeyName,
+    UIElementFromSelection,
+    selectedElementJsonSchema,
+    selectionDisplayName,
+  }
+}

--- a/packages/forms-designer/MainLayout.tsx
+++ b/packages/forms-designer/MainLayout.tsx
@@ -21,7 +21,7 @@ export const MainLayout: FunctionComponent<Props> = ({ appBar, children, additio
   const wizardPaperRef = useRef<null | HTMLDivElement>(null)
   const dispatch = useAppDispatch()
   const previewModus = useAppSelector(selectPreviewModus)
-  const { selectedKey } = useToolSettings()
+  const { selectedPath } = useToolSettings()
   const handleTogglePreview = (event: any) => {
     dispatch(togglePreviewModus())
   }
@@ -66,7 +66,7 @@ export const MainLayout: FunctionComponent<Props> = ({ appBar, children, additio
         <Drawer
           variant="persistent"
           anchor="right"
-          open={Boolean(selectedKey)}
+          open={Boolean(selectedPath)}
           sx={{
             width: drawerWidth,
             flexShrink: 0,

--- a/packages/forms-designer/useAutoDeselectOnOutsideClick.ts
+++ b/packages/forms-designer/useAutoDeselectOnOutsideClick.ts
@@ -1,11 +1,9 @@
-import { selectElement, selectPath, useAppDispatch } from '@formswizard/state'
+import { selectPath, useAppDispatch } from '@formswizard/state'
 import React, { useCallback } from 'react'
 
 function useAutoDeselectOnOutsideClick(wizardPaperRef) {
   const dispatch = useAppDispatch()
   const handleDeselect = useCallback(() => {
-    // @ts-ignore
-    dispatch(selectElement(null))
     // @ts-ignore
     dispatch(selectPath(null))
   }, [dispatch])

--- a/packages/renderer/drop-renderer/LayoutElement.tsx
+++ b/packages/renderer/drop-renderer/LayoutElement.tsx
@@ -11,7 +11,7 @@ import {
 import { JsonFormsDispatch, useJsonForms } from '@jsonforms/react'
 import { Box, Grid } from '@mui/material'
 import React, { useCallback, useMemo } from 'react'
-import { useAppDispatch, useAppSelector, selectElement, selectSelectedElementKey, selectPath } from '@formswizard/state'
+import { useAppDispatch, useAppSelector, selectSelectedPath, selectPath } from '@formswizard/state'
 import classnames from 'classnames'
 import { useDNDHooksContext, useDragTarget, useDropTarget } from '@formswizard/react-hooks'
 
@@ -36,7 +36,7 @@ import { useDNDHooksContext, useDragTarget, useDropTarget } from '@formswizard/r
 //     </>
 //   )
 // }
-
+type UISchemaElementWithPath = UISchemaElement & { path: string; structurePath?: string }
 type LayoutElementProps = {
   index: number
   direction: 'row' | 'column'
@@ -50,56 +50,36 @@ type LayoutElementProps = {
   parent: UISchemaElement[]
 }
 
-const LayoutElement = ({
-  index,
-  direction,
-
-  schema,
-  path,
-  enabled,
-  element: child,
-  cells,
-  parent,
-  renderers,
-}: LayoutElementProps) => {
+const LayoutElement = ({ index, schema, path, enabled, element: child, cells, renderers }: LayoutElementProps) => {
   const ctx = useJsonForms()
   const state = { jsonforms: ctx }
   const rootSchema = getSchema(state)
-  //const rootData = getData(state)
   const dispatch = useAppDispatch()
-
-  const selectedKey = useAppSelector(selectSelectedElementKey)
+  const selectedPath = useAppSelector(selectSelectedPath)
   const controlName = useMemo<string | undefined>(
     () => (child.type === 'Control' ? composeWithUi(child as ControlElement, path) : undefined),
     [child, path]
   )
-
   const resolvedSchema = useMemo<JsonSchema | undefined>(
     () => Resolve.schema(schema || rootSchema, (child as ControlElement).scope, rootSchema),
 
     [schema, rootSchema, child]
   )
-
   const key = useMemo<string>(
     () => (controlName ? controlName : `${child.type}-${index}`),
     [controlName, index, child.type]
   )
-  const isGroup = useMemo<boolean>(() => child.type === 'Group', [child])
   const { handleAllDrop, handleDropAtStart, draggedMeta } = useDropTarget({ child })
   const { useDrop, useDragLayer } = useDNDHooksContext()
   const anythingDragging = useDragLayer((monitor) => monitor.isDragging())
   const [{ isDragging }, dragRef] = useDragTarget({ child, name: controlName, resolvedSchema })
-  // const anythingDragging = true
   const [{ isOver: isOver1, isOverCurrent: isOverCurrent1 }, dropRef] = useDrop(handleAllDrop, [handleAllDrop])
   const [{ isOver: isOver2, isOverCurrent: isOverCurrent2 }, dropRef2] = useDrop(handleAllDrop, [handleAllDrop])
   const [{ isOver: isOver3, isOverCurrent: isOverCurrent3 }, dropRef3] = useDrop(handleDropAtStart, [handleAllDrop])
-  const isOver = isOver1 || isOver2
   const isOverCurrent = isOverCurrent1 || isOverCurrent2
   const handleSelect = useCallback(
     (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
       event.stopPropagation()
-      // @ts-ignore
-      dispatch(selectElement(key))
       // @ts-ignore
       dispatch(selectPath(child.path))
     },
@@ -122,20 +102,7 @@ const LayoutElement = ({
           dropRef={dropRef3}
           anythingDragging={isDragging || anythingDragging}
         ></LayoutDropArea>
-        // <Paper
-        //   sx={{
-        //     border: 'none',
-        //     opacity: isOver3 ? '1.0' : '0.2',
-        //     minWidth: '2em',
-        //     minHeight: '1.5em',
-        //     // bgcolor: (theme) => (isOver ?  theme. : 'none'),
-        //     padding: 4,
-        //     backgroundColor: isOver3 ? 'yellow' : 'red',
-        //   }}
-        //   ref={dropRef3}
-        // ></Paper>
       )}
-
       <Grid key={key} item ref={dropRef} xs onClick={handleSelect}>
         <Box
           // elevation={selectedKey === key ? 4 : 0}
@@ -143,7 +110,8 @@ const LayoutElement = ({
             flexGrow: 1,
             display: 'flex',
             backgroundColor: (theme) =>
-              selectedKey === key
+              // @ts-ignore
+              selectedPath === child.path
                 ? theme.palette.mode === 'dark'
                   ? theme.palette.grey[800]
                   : theme.palette.grey[200]

--- a/packages/state/wizard/exampleState.ts
+++ b/packages/state/wizard/exampleState.ts
@@ -2,7 +2,7 @@ import { JsonSchema, Scopable, UISchemaElement } from '@jsonforms/core'
 export type JsonFormsEditState = {
   jsonSchema: JsonSchema
   uiSchema?: any
-  selectedElementKey?: string | null
+  // selectedElementKey?: string | null
   selectedPath?: string
 }
 

--- a/packages/state/wizard/jsonFormsEditSlice.ts
+++ b/packages/state/wizard/jsonFormsEditSlice.ts
@@ -36,7 +36,7 @@ export const selectJsonSchema = (state: RootState) => state.jsonFormsEdit.jsonSc
 
 export const selectUiSchema = (state: RootState) => state.jsonFormsEdit.uiSchema
 
-export const selectSelectedElementKey = (state: RootState) => state.jsonFormsEdit.selectedElementKey
+// export const selectSelectedElementKey = (state: RootState) => state.jsonFormsEdit.selectedElementKey
 export const selectSelectedPath = (state: RootState) => state.jsonFormsEdit.selectedPath
 
 //TODO: document further
@@ -507,11 +507,21 @@ export const selectSelectedElementJsonSchema: (state: RootState) => JsonSchema |
     return resolveSchema(jsonSchema, selectedUiSchema.scope, jsonSchema)
   }
 )
-export const selectSelectionDisplayName: (state: RootState) => JsonSchema | null = createSelector(
+export const selectSelectionDisplayName: (state: RootState) => string | null = createSelector(
   selectSelectedElementJsonSchema,
   selectUIElementFromSelection,
   (selectedJsonSchema, selectedUiSchema) => {
+    console.log({ selectedJsonSchema, selectedUiSchema })
+    if (selectedUiSchema && isScopableUISchemaElement(selectedUiSchema)) {
+      return prettyPrintScope(selectedUiSchema.scope)
+    }
     // @ts-ignore
-    return selectedJsonSchema?.title || selectedUiSchema?.label || selectedUiSchema?.scope || null
+    return selectedJsonSchema?.title || selectedUiSchema?.label || null
   }
 )
+
+const prettyPrintScope = (scope) =>
+  scope
+    .split('/')
+    .filter((s) => s !== '#' && s !== 'properties')
+    .join(' > ')

--- a/packages/state/wizard/jsonFormsEditSlice.ts
+++ b/packages/state/wizard/jsonFormsEditSlice.ts
@@ -244,9 +244,9 @@ export const jsonFormsEditSlice = createSlice({
   name: 'jsonFormEdit',
   initialState: exampleInitialState,
   reducers: {
-    selectElement: (state: JsonFormsEditState, action: PayloadAction<string | undefined>) => {
-      state.selectedElementKey = action.payload
-    },
+    // selectElement: (state: JsonFormsEditState, action: PayloadAction<string | undefined>) => {
+    //   state.selectedElementKey = action.payload
+    // },
     selectPath: (state: JsonFormsEditState, action: PayloadAction<string | undefined>) => {
       state.selectedPath = action.payload
     },
@@ -256,7 +256,7 @@ export const jsonFormsEditSlice = createSlice({
       if (!jsonSchema || !uiSchema) {
         return
       }
-      state.selectedElementKey = null
+      // state.selectedElementKey = null
 
       state.jsonSchema = jsonSchema
       state.uiSchema = uiSchema
@@ -297,7 +297,7 @@ export const jsonFormsEditSlice = createSlice({
 
       if (path === state.selectedPath) {
         state.selectedPath = undefined
-        state.selectedElementKey = undefined
+        // state.selectedElementKey = undefined
       }
 
       if (parent) {
@@ -458,7 +458,7 @@ export const jsonFormsEditSlice = createSlice({
 
 export const {
   insertControl,
-  selectElement,
+  // selectElement,
   selectPath,
   renameField,
   removeFieldOrLayout,
@@ -505,5 +505,13 @@ export const selectSelectedElementJsonSchema: (state: RootState) => JsonSchema |
     }
 
     return resolveSchema(jsonSchema, selectedUiSchema.scope, jsonSchema)
+  }
+)
+export const selectSelectionDisplayName: (state: RootState) => JsonSchema | null = createSelector(
+  selectSelectedElementJsonSchema,
+  selectUIElementFromSelection,
+  (selectedJsonSchema, selectedUiSchema) => {
+    // @ts-ignore
+    return selectedJsonSchema?.title || selectedUiSchema?.label || selectedUiSchema?.scope || null
   }
 )


### PR DESCRIPTION
All selection depends on the selected UI element. useWizardSelections exposes useful selectors, all of which internally depend on the selected ui schema, such as:

selectedKeyName,
UIElementFromSelection,
selectedElementJsonSchema,
selectionDisplayName.

The renaming reimplemented with the this approach, and editable key input is put in a separate file